### PR TITLE
fix(paths): cross-platform references

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -57,15 +57,10 @@ in order to avoid adding the UI5 sources to version control`);
                 reject(errMsg);
                 return false;
             }
-            if (!helpers.isUrl(from)) {
-                if (!helpers.isFile(from)) {
-                    let errMsg = `${from} is not a valid file system path...exiting`;
-                    reject(errMsg);
-                    return false;
-                }
-                let errMsg = `${from} is not a valid URL...exiting`;
-                reject(errMsg);
-                return false;
+            if (!helpers.isUrl(from) && !helpers.isFile(from)) {
+                 let errMsg = `${from} is not a valid file system path...exiting`;
+                 reject(errMsg);
+                 return false;
             }
             
             if (helpers.isUrl(from)) {
@@ -145,7 +140,8 @@ in order to avoid adding the UI5 sources to version control`);
             if (fs.existsSync(sFallbackFile)) {
                 fs.writeFileSync(sFileName, fs.readFileSync(sFallbackFile));
             } else {
-                console.error(`fallbackfile ${sFallbackFile} does not exist`);
+                console.error(`fallbackfile ${sFallbackFile} does not exist - 
+sure we're working a WebStorm project dir here!?`);
             }
         } else {
             let sIdeaModules = fs.readFileSync(sFileName, 'utf8');
@@ -195,7 +191,7 @@ in order to avoid adding the UI5 sources to version control`);
                     }
                 }, at: "project.component[0].file"
             }
-        ], path.join(process.cwd(), '/.idea/jsLibraryMappings.xml'), path.join(__dirname, '../resources/jsLibraryMappings.xml'));
+        ], path.join(process.cwd(), '.idea', 'jsLibraryMappings.xml'), path.join(__dirname, '..' , 'resources', 'jsLibraryMappings.xml'));
 
         return true;
     },
@@ -207,14 +203,15 @@ in order to avoid adding the UI5 sources to version control`);
         let aLibFiles;
         let oHbsTemplate;
 
-        let sSourcePath = path.join(location, 'resources');
+        let sAbsPath = path.join(location, 'resources');
+        let sSourcePath = path.relative(process.cwd(), sAbsPath);
         aLibFiles = glob.sync(`${sSourcePath}/**/*dbg.js`, {ignore: '**/*-all*.js'});
         console.log(`providing code completion from 
    ${sSourcePath} 
 for ${aLibFiles.length} files (*dbg.js only).`);
-        oHbsTemplate = hbs.compile(fs.readFileSync(path.join(__dirname, '../resources/LocalUI5LibraryTemplate.hbs')).toString());
-        fs.ensureDirSync('.idea/libraries');
-        fs.writeFileSync('.idea/libraries/LocalUI5Library.xml', oHbsTemplate({sourceFiles: aLibFiles}));
+        oHbsTemplate = hbs.compile(fs.readFileSync(path.join(__dirname, '..', 'resources', 'LocalUI5LibraryTemplate.hbs')).toString());
+        fs.ensureDirSync(path.join('.idea', 'libraries'));
+        fs.writeFileSync(path.join('.idea', 'libraries', 'LocalUI5Library.xml'), oHbsTemplate({sourceFiles: aLibFiles}));
         return true;
     }
 };

--- a/resources/jsLibraryMappings.xml
+++ b/resources/jsLibraryMappings.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
     <component name="JavaScriptLibraryMappings">
-        <file url="file://$PROJECT_DIR$/src" libraries="{LocalUI5Library}" />
-        <file url="file://$PROJECT_DIR$/test" libraries="{LocalUI5Library}" />
+        <file url="file://$PROJECT_DIR$" libraries="{LocalUI5Library}" />
         <file url="PROJECT" libraries="{LocalUI5Library}" />
     </component>
 </project>


### PR DESCRIPTION
- more solid URL + path determination (for --from)
- refactored path references cross-platform consistently
- fix: refs to $project_dir/local/ui5/lib to be correctly transferred
  to .xml lib file + unit test
- default: scope for ui5 code completion for entire directory