### PR TITLE
feat(UI5): get latests UI5 version async from API

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -3,30 +3,31 @@ const yargs = require('yargs');
 const path = require('path');
 const constants = require('../lib/constants');
 
-const bin = yargs.commandDir(path.join(__dirname, '../', 'lib', '_commands'))
-    .help('help')
-    .alias('h', 'help')
-    .showHelpOnFail(false, "specify --help for available options")
-    .usage('Usage: ui5-codecompletion <command> [options]')
-    .describe('from', `URL or file system path to zip-file w/ UI5 runtime sources, defaults to "${constants.defaultUI5version}"`)
-    .describe('to', `file system path, relative to $project_dir, to store UI5 sources in; defaults to "${constants.unzipPath}"`)
-    .describe('sourceDir', `file system path, relative to $project_dir, to configure code completion with; defaults to "${constants.sourceDir}"`)
-    .alias('f', 'from')
-    .alias('t', 'to')
-    .alias('s', 'sourceDir')
-    .example('ui5-codecompletion install', 'downloads and configures UI5 with default options')
-    .example('ui5-codecompletion install --from=https://url/openui5-runtime.zip', 
-        `installs UI5 from the specified URL to ${constants.unzipPath}`)
-    .example('ui5-codecompletion install \\\n> -f=https://url/openui5-runtime.zip \\\n> -t=ui5/sources/local', 
-        'installs UI5 from the URL pointing to the .zip, to $project_dir/ui5/sources/local')
-    .example('ui5-codecompletion configure', `uses UI5 sources in ${constants.sourceDir} to configure code completion`)
-    .example('ui5-codecompletion configure --sourceDir=my/relative/dir/ui5' ,
-        'uses UI5 sources in $project_dir/my/relative/dir/ui5 to configure code completion')
-    .example('ui5-codecompletion configure -s=dir/ui5' ,
-        'uses UI5 sources in $project_dir/dir/ui5 to configure code completion')
-    .demandCommand(1, 'at least one command (install|configure) needs to be provided!')
-    .argv;
-
+const bin = (async function () {
+    const execute = yargs.commandDir(path.join(__dirname, '../', 'lib', '_commands'))
+        .help('help')
+        .alias('h', 'help')
+        .showHelpOnFail(false, "specify --help for available options")
+        .usage('Usage: ui5-codecompletion <command> [options]')
+        .describe('from', `URL or file system path to zip-file w/ UI5 runtime sources, defaults to "${await constants.defaultUI5version.then(res=>res)}"`)
+        .describe('to', `file system path, relative to $project_dir, to store UI5 sources in; defaults to "${constants.unzipPath}"`)
+        .describe('sourceDir', `file system path, relative to $project_dir, to configure code completion with; defaults to "${constants.sourceDir}"`)
+        .alias('f', 'from')
+        .alias('t', 'to')
+        .alias('s', 'sourceDir')
+        .example('ui5-codecompletion install', 'downloads and configures UI5 with default options')
+        .example('ui5-codecompletion install --from=https://url/openui5-runtime.zip',
+            `installs UI5 from the specified URL to ${constants.unzipPath}`)
+        .example('ui5-codecompletion install \\\n> -f=https://url/openui5-runtime.zip \\\n> -t=ui5/sources/local',
+            'installs UI5 from the URL pointing to the .zip, to $project_dir/ui5/sources/local')
+        .example('ui5-codecompletion configure', `uses UI5 sources in ${constants.sourceDir} to configure code completion`)
+        .example('ui5-codecompletion configure --sourceDir=my/relative/dir/ui5' ,
+            'uses UI5 sources in $project_dir/my/relative/dir/ui5 to configure code completion')
+        .example('ui5-codecompletion configure -s=dir/ui5' ,
+            'uses UI5 sources in $project_dir/dir/ui5 to configure code completion')
+        .demandCommand(1, 'at least one command (install|configure) needs to be provided!')
+        .argv;
+})();
 
 module.exports = bin;
 

--- a/lib/_commands/install.js
+++ b/lib/_commands/install.js
@@ -6,13 +6,13 @@ module.exports = {
     desc: 'downloads (if URL) or copies (if fs path) and configures a UI5 runtime library for code completion',
     builder: {
         from: {
-            default: constants.defaultUI5version
+            default: constants.defaultUI5version.then( res => res)
         },
         to: {
             default: constants.unzipPath
         }
     },
-    handler: args => {
-        install(args.from, args.to)
+    handler: async args => {
+        install(await args.from, args.to)
     }
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,25 +4,13 @@ const request = require('request');
 
 const constants = function () {
 const defaultUI5version = new Promise((resolve, reject) => {
-    let req = request('https://latest-openui5.rikosjett.com/api/v1/latest');
-    let data = '';
-    req
-        .on('error', (err) => {
-            req.abort();
-            reject(err);
-        })
-        .on('response', function (response) {
-            if (response.statusCode === 404) {
-                reject();
-                req.abort();
+        const url = 'https://latest-openui5.rikosjett.com/api/v1/latest';
+        request(url, (err, resp, content) => {
+            if (err) {
+                reject(err);
             }
-        })
-        .on('data', (chunk) => {
-            data += chunk;
-        })
-        .on('close', function (err) {
-            resolve(data);
-        })
+            resolve(content);
+        });
 });
 
 return {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,11 +1,42 @@
 const os = require('os');
 const path = require('path');
+const request = require('request');
 
-const constants = {
-    tmpDownloadFile: path.join(os.tmpdir(),'ui5.zip'),
-    unzipPath: '.ui5', // install command: target for unzipping
-    sourceDir: '.ui5', // for configure command: where are the extracted ui5 sources stored
-    defaultUI5version: 'https://openui5.hana.ondemand.com/downloads/openui5-runtime-1.61.2.zip'
+const constants = function () {
+const defaultUI5version = new Promise((resolve, reject) => {
+    let req = request('https://latest-openui5.rikosjett.com/api/v1/latest');
+    let data = '';
+    req
+        .on('error', (err) => {
+            req.abort();
+            reject(err);
+        })
+        .on('response', function (response) {
+            if (response.statusCode === 404) {
+                reject();
+                req.abort();
+            }
+        })
+        .on('data', (chunk) => {
+            data += chunk;
+        })
+        .on('close', function (err) {
+            resolve(data);
+        })
+});
+
+return {
+        tmpDownloadFile: path.join(os.tmpdir(),'ui5.zip'),
+        unzipPath: '.ui5', // install command: target for unzipping
+        sourceDir: '.ui5', // for configure command: where are the extracted ui5 sources stored
+        defaultUI5version: defaultUI5version
+    }
+
+
+
 };
 
-module.exports = constants;
+module.exports = constants();
+
+
+

--- a/test/general.js
+++ b/test/general.js
@@ -15,7 +15,8 @@ it('should show a hint if called with no commands/options', function () {
     expect(child.stderr).to.include('at least one command');
 });     
 
-it('should show usage information if called with either -h or --help', function() {
+it('should show usage information if called with --help', function() {
+
     function expectations(stderr, stdout) {
         "use strict";
         expect(stderr).to.be.empty;
@@ -23,13 +24,6 @@ it('should show usage information if called with either -h or --help', function(
             .and.include('install [from]')
             .and.include('configure');
     }
-    
-    const ui5cc_h = path.join(process.cwd(), "bin/index.js");
-    const child_h = spawnSync(ui5cc_h, ["-h"], {
-        stdio: 'pipe',
-        encoding: 'utf-8'
-    });
-    expectations(child_h.stderr, child_h.stdout);
 
     const ui5cc_help = path.join(process.cwd(), "bin/index.js");
     const child_help = spawnSync(ui5cc_help, ["--help"], {
@@ -37,5 +31,24 @@ it('should show usage information if called with either -h or --help', function(
         encoding: 'utf-8'
     });
     expectations(child_help.stderr, child_help.stdout);
+});
 
+it('should show usage information if called with -h', function() {
+
+    function expectations(stderr, stdout) {
+        "use strict";
+        expect(stderr).to.be.empty;
+        expect(stdout).to.include('Usage: ui5-codecompletion')
+            .and.include('install [from]')
+            .and.include('configure');
+        
+    }
+
+    const ui5cc_h = path.join(process.cwd(), "bin/index.js");
+    const child_h = spawnSync(ui5cc_h, ["-h"], {
+        stdio: 'pipe',
+        encoding: 'utf-8'
+    });
+    expectations(child_h.stderr, child_h.stdout);
+    
 });

--- a/test/install.js
+++ b/test/install.js
@@ -4,10 +4,10 @@ const proxyquire = require('proxyquire').noPreserveCache();
 const fs = require('fs-extra');
 
 describe("from parameter", function () {
-    it("should be set to the default value if omitted", function () {
+    it("should be set to the default value if omitted", async function () {
         const {builder} = require('../lib/_commands/install');
         const constants = require('../lib/constants');
-        expect(builder.from.default).to.be.equal(constants.defaultUI5version);
+        expect(await builder.from.default).to.be.equal(await constants.defaultUI5version.then(res=>res));
     });
     it("should allow local file path to a UI5 zip", function () {
         const helpers = require('../lib/helpers');


### PR DESCRIPTION
Implemented a solution to get URL to latest version of OpenUI5 form API at https://latest-openui5.rikosjett.com/. Tried to create a solution that keep changes to original code to a minimum. 

Split test in general.js, as it timed out (2000ms) and failed. All tests pass.